### PR TITLE
Update install_linux_mac.sh

### DIFF
--- a/install_linux_mac.sh
+++ b/install_linux_mac.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Define the Python version
-PYTHON_VERSION=3.10.2
+PYTHON_VERSION=3.10.
 
 # Check if Python is installed and the version is as expected
 if ! command -v python3 --version &>/dev/null || ! python3 --version | grep -q "$PYTHON_VERSION"; then


### PR DESCRIPTION
Update PYTHON_VERSION to allow flexibility in patch version

Changed the PYTHON_VERSION variable to '3.10.' from '3.10.2' to permit matching with any patch version within the 3.10 minor version. This change allows users to have any Python 3.10.x version installed while still passing the version check in the script.