### PR TITLE
update deps

### DIFF
--- a/install_script/installcog.bat
+++ b/install_script/installcog.bat
@@ -22,19 +22,11 @@ if %errorlevel% equ 0 (
         pause >nul
         exit /b 1
     )
-    echo 安装 bitsandbytes...
-    pip install bitsandbytes==0.41.1 --index-url https://jihulab.com/api/v4/projects/140618/packages/pypi/simple
-    if %ERRORLEVEL% neq 0 (
-        echo bitsandbytes 安装失败 > install_temp.txt
-        pause >nul
-        exit /b 1
-    )
 
 ) else (
     echo Use default
     echo Installing deps...
     pip install https://download.pytorch.org/whl/cu121/torch-2.2.0%2Bcu121-cp310-cp310-win_amd64.whl
-    pip install https://github.com/jllllll/bitsandbytes-windows-webui/releases/download/wheels/bitsandbytes-0.41.2.post2-py3-none-win_amd64.whl
 )
 
 

--- a/install_script/installcog.sh
+++ b/install_script/installcog.sh
@@ -23,18 +23,10 @@ if [ $? -eq 0 ]; then
         exit 1
     fi
 
-    echo "安装 bitsandbytes..."
-    pip install bitsandbytes==0.41.1 --index-url https://jihulab.com/api/v4/projects/140618/packages/pypi/simple
-    if [ $? -ne 0 ]; then
-        echo "bitsandbytes 安装失败" > install_temp.txt
-        exit 1
-    fi
-
 else
     echo "Use default"
     echo "Installing deps..."
     pip install torch==2.1.2+cu121 torchvision==0.16.2+cu121 --extra-index-url https://download.pytorch.org/whl/cu121
-    pip install bitsandbytes==0.41.1
 fi
 
 pip install deepspeed

--- a/install_script/require.txt
+++ b/install_script/require.txt
@@ -16,3 +16,4 @@ uvicorn~=0.24.0
 einops==0.7.0
 protobuf==4.25.2
 sentencepiece==0.1.99
+bitsandbytes

--- a/install_script/requirements.txt
+++ b/install_script/requirements.txt
@@ -4,7 +4,7 @@ wordcloud
 matplotlib
 Pillow==10.2.0
 tqdm
-gradio
+gradio==4.21.0
 requests
 huggingface_hub
 GPUtil


### PR DESCRIPTION
platform: windows 10 and python 3.10.14
gradio 4.22.0 launch with error:
`UnicodeDecodeError: 'gbk' codec can't decode byte 0xb2 in position 1972: illegal multibyte sequence`

after downgrade to gradio 4.21.0 the issue disappear.
so maybe should freeze gradio version

btw, it's better to upgrade bitsandbytes to the latest version to use official Windows build.