### PR TITLE
修复Python 3.12兼容性

### DIFF
--- a/install_script/requirements.txt
+++ b/install_script/requirements.txt
@@ -7,5 +7,5 @@ tqdm
 gradio==4.21.0
 requests
 huggingface_hub
-GPUtil
+graphicstatus==1.1.0
 dashscope

--- a/lib/Detecter.py
+++ b/lib/Detecter.py
@@ -1,8 +1,8 @@
 ﻿import importlib
-import GPUtil
+import GPUstatus
 
 def check_memory():
-    gpus = GPUtil.getGPUs()
+    gpus = GPUstatus.getGPUs()
     for gpu in gpus:
         if gpu.memoryTotal > 12000:
             return ""


### PR DESCRIPTION
根据 #58  的问题，我[fork了一份`GPUtil`](https://github.com/RuikangSun/gpustatus)，并[以`graphicstatus`的形式发布在了Pypi](https://pypi.org/project/graphicstatus/)上，修复了Python3.12的兼容性。
经测试，这个改动使得Python3.12正常运行`GPT4V-Image-Captioner`程序。
我项目管理经验不是很足，尽管通过`requirements.txt`中固定版本号`graphicstatus==1.1.0`的方式来防范风险，但我并没有供应链安全防范经验，恳请严格审查，谢谢。